### PR TITLE
docs: Update README with accurate commands and comprehensive testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,67 @@
 # QEMU ACPI Hardware Info
 
-A tool for embedding host hardware information into QEMU virtual machines via ACPI tables, allowing guests to access host hardware identifiers like NVMe serial numbers and MAC addresses.
+A Nix-based tool for embedding host hardware information into QEMU virtual machines via ACPI tables, allowing guests to access host hardware identifiers like NVMe serial numbers and MAC addresses.
 
-## Quick Start with Nix (Recommended)
+## 🚀 Quick Start & Testing
 
-If you have Nix with flakes enabled:
+The easiest way to test the functionality:
 
 ```bash
-# Enter development environment with all dependencies
+# Clone and enter the development environment
+git clone https://github.com/juliuskoskela/qemu-acpi-hwinfo.git
+cd qemu-acpi-hwinfo
 nix develop
 
-# Check hardware info status
-nix run .#hwinfo-status
+# Test the complete workflow with a VM
+run-test-vm-with-hwinfo
 
-# Generate hardware info
-nix run .#acpi-hwinfo-generate
-
-# Show current hardware info
-nix run .#acpi-hwinfo-show
-
-# Start QEMU with hardware info
-nix run .#qemu-with-hwinfo -- disk.qcow2
+# Or run automated tests (exits automatically)
+run-automated-vm-test
 ```
 
-## NixOS Modules
+This will:
+1. Build a NixOS VM with ACPI hardware info support
+2. Inject your host's NVMe serial and MAC address via ACPI
+3. Boot the VM and automatically test hardware detection
+4. Show detected hardware info in the guest
 
-This flake provides two NixOS modules:
+## 📦 Available Commands
+
+### Development Environment (nix develop)
+
+```bash
+nix develop  # Enter development shell with all tools
+
+# Main commands available in devshell:
+acpi-hwinfo                 # Show hardware detection status
+run-test-vm-with-hwinfo     # Test VM with hardware info injection  
+run-automated-vm-test       # Automated test (auto-exit)
+create-test-hwinfo          # Create test hardware info files
+qemu-with-hwinfo           # Start QEMU with hardware info
+integration-test           # Run integration tests
+```
+
+### Direct Package Usage
+
+```bash
+# Hardware detection and generation
+nix run .#hwinfo-status           # Check hardware detection status
+nix run .#acpi-hwinfo-generate    # Generate ACPI hardware info
+nix run .#acpi-hwinfo-show        # Show current hardware info
+
+# Testing and VM management  
+nix run .#run-test-vm-with-hwinfo # Run test VM with hardware info
+nix run .#run-automated-vm-test   # Automated VM test
+nix run .#qemu-with-hwinfo        # Start QEMU with hardware info
+
+# MicroVM testing
+nix run .#run-test-microvm        # Test with MicroVM
+nix run .#run-automated-microvm-test # Automated MicroVM test
+```
+
+## 🔧 NixOS Modules
+
+This flake provides NixOS modules for both host and guest systems:
 
 ### Host Module (`acpi-hwinfo-host`)
 
@@ -33,12 +69,17 @@ For the host system that generates hardware info:
 
 ```nix
 {
+  inputs.qemu-acpi-hwinfo.url = "github:juliuskoskela/qemu-acpi-hwinfo";
+  
+  # In your NixOS configuration:
   imports = [ inputs.qemu-acpi-hwinfo.nixosModules.acpi-hwinfo-host ];
   
   services.acpi-hwinfo = {
     enable = true;
     generateOnBoot = true;  # Generate hardware info at boot
-    # Optional overrides:
+    dataDir = "/var/lib/acpi-hwinfo";  # Storage directory
+    
+    # Optional overrides (auto-detected if not specified):
     # nvmeSerial = "custom-serial";
     # macAddress = "00:11:22:33:44:55";
   };
@@ -55,105 +96,132 @@ For VMs that need to read hardware info:
   
   virtualisation.acpi-hwinfo = {
     enable = true;
-    enableMicrovm = true;  # For MicroVM integration
+    enableMicrovm = false;        # Set to true for MicroVM integration
+    enableQemuIntegration = true; # QEMU integration (default)
     hostHwinfoPath = "/var/lib/acpi-hwinfo/hwinfo.aml";
-    guestTools = true;     # Install guest reading tools
+    guestTools = true;           # Install guest reading tools
   };
 }
 ```
 
-## Architecture
+### Combined Module
+
+For systems that act as both host and guest:
+
+```nix
+{
+  imports = [ inputs.qemu-acpi-hwinfo.nixosModules.acpi-hwinfo ];
+  
+  # Enables both host and guest functionality
+  services.acpi-hwinfo.enable = true;
+  virtualisation.acpi-hwinfo.enable = true;
+}
+```
+
+## 🏗️ Architecture
 
 The project uses a clean modular structure:
 
 ```
 ├── modules/           # NixOS modules
-│   ├── host.nix      # Host-side hardware detection
-│   ├── guest.nix     # Guest-side VM configuration
+│   ├── host.nix      # Host-side hardware detection & ACPI generation
+│   ├── guest.nix     # Guest-side VM configuration & tools
 │   └── default.nix   # Module exports
-├── packages/          # Nix packages
-│   └── default.nix   # Package definitions
-├── scripts/           # Shell scripts
-│   ├── acpi-hwinfo-generate.sh
-│   ├── acpi-hwinfo-show.sh
-│   ├── hwinfo-status.sh
-│   └── qemu-with-hwinfo.sh
+├── packages/          # Nix packages & tools
+│   └── default.nix   # All package definitions
+├── tests/             # Test configurations
+│   ├── microvm.nix   # MicroVM test setup
+│   └── vm.nix        # Standard VM test setup
 ├── nix/              # Development tooling
 │   ├── devshell.nix  # Development environment
 │   ├── formatter.nix # Code formatting
-│   └── lib.nix       # Helper functions
-└── examples/         # Example configurations
-    ├── example-vm.nix
-    └── microvm.nix
+│   └── lib.nix       # Shared hardware detection logic
+└── flake.nix         # Main flake configuration
 ```
 
-## Traditional Usage (without Nix)
+## 🔍 Hardware Detection
 
-### Prerequisites
+The system uses multiple detection methods with fallbacks:
 
-- `iasl` (Intel ACPI Source Language Compiler)
-- `qemu-system-x86_64`
-- Root/sudo access for reading hardware information
+### NVMe Serial Detection
+1. **Primary**: `nvme id-ctrl /dev/nvmeX` (most reliable)
+2. **Fallback**: `nvme list` output parsing  
+3. **Last resort**: `/sys/class/nvme/nvme0/serial`
 
-**Ubuntu/Debian:**
-```bash
-sudo apt install acpica-tools qemu-system-x86
-```
+### MAC Address Detection
+1. **Primary**: `ip link show` first ethernet interface
+2. **Fallback**: Network interface enumeration
 
-**RHEL/Fedora:**
-```bash
-sudo dnf install acpica-tools qemu-system-x86
-```
+### Enhanced Features
+- **Validation**: Hardware info format validation
+- **Debug mode**: `ACPI_HWINFO_DEBUG=true` for detailed logging
+- **Error handling**: Comprehensive fallback mechanisms
 
-### 1. Generate ACPI Table
+## 🔧 How It Works
 
-Auto-detect hardware:
-```bash
-./qemu-acpi-hwinfo.sh
-```
+The system follows a clean workflow:
 
-Or specify custom values:
-```bash
-./qemu-acpi-hwinfo.sh CUSTOM_NVME_SERIAL 00:11:22:33:44:55
-```
+1. **Hardware Detection**: Host system detects NVMe serial numbers and MAC addresses using multiple methods
+2. **ACPI Generation**: Creates an ACPI SSDT table containing the hardware information  
+3. **VM Integration**: QEMU loads the ACPI table, making it available to the guest OS
+4. **Guest Access**: Guest systems can query the ACPI interface to retrieve hardware info
 
-This creates `hwinfo.aml` containing the ACPI table.
-
-### 2. Start Virtual Machine
-
-```bash
-./start-vm.sh [disk_image] [memory]
-```
-
-Examples:
-```bash
-./start-vm.sh                    # Uses disk.qcow2 and 2G RAM
-./start-vm.sh ubuntu.qcow2 4G    # Custom disk and memory
-```
-
-### 3. Read Hardware Info in Guest
-
-Inside the virtual machine:
-```bash
-./guest-read-hwinfo.sh
-```
-
-## How It Works
-
-1. The host script detects NVMe serial numbers and MAC addresses
-2. An ACPI SSDT table is generated containing this information
-3. QEMU loads the table, making it available to the guest OS
-4. The guest can query the ACPI interface to retrieve the hardware info
-
-## Hardware Detection
-
-- **NVMe Serial**: Uses `nvme` command or `/sys/class/nvme/nvme0/serial`
-- **MAC Address**: Extracts from first Ethernet interface via `ip link`
-
-## ACPI Table Structure
+### ACPI Table Structure
 
 The generated SSDT creates a device `\_SB.HWIN` with:
-- Device ID: `ACPI0001`
-- Method `GHWI`: Returns hardware info as a package
-- Always reports as present and enabled
+- **Device ID**: `ACPI0001` 
+- **Method `GHWI`**: Returns hardware info as an ACPI package
+- **Status**: Always reports as present and enabled
+- **Format**: Structured data accessible via standard ACPI interfaces
+
+### Integration Points
+
+- **NixOS Module**: Automatic hardware detection and ACPI generation
+- **MicroVM**: Native integration with MicroVM hypervisor
+- **QEMU**: Standard QEMU ACPI table injection
+- **Guest Tools**: Utilities for reading hardware info in VMs
+
+## 🧪 Testing & Development
+
+### Running Tests
+
+```bash
+# Enter development environment
+nix develop
+
+# Quick test with VM
+run-test-vm-with-hwinfo
+
+# Automated testing (exits automatically)  
+run-automated-vm-test
+
+# MicroVM testing
+nix run .#run-test-microvm
+
+# Integration tests
+integration-test
+```
+
+### Debug Mode
+
+Enable detailed logging for troubleshooting:
+
+```bash
+ACPI_HWINFO_DEBUG=true nix run .#acpi-hwinfo-generate
+ACPI_HWINFO_DEBUG=true run-test-vm-with-hwinfo
+```
+
+### Development Workflow
+
+1. **Make changes** to modules or packages
+2. **Test locally** with `run-test-vm-with-hwinfo`
+3. **Run automated tests** with `run-automated-vm-test`
+4. **Verify integration** with `integration-test`
+
+## 📋 Requirements
+
+- **Nix** with flakes enabled
+- **Linux host** (for hardware detection)
+- **KVM support** (for VM testing)
+- **Sufficient RAM** (2GB+ recommended for VMs)
 


### PR DESCRIPTION
## 📚 README Overhaul

This PR completely updates the README to accurately reflect the current implementation and provide a comprehensive testing guide.

## ✅ Key Improvements

### 🎯 **Accurate Command Documentation**
- **Verified all commands**: Every command in the README has been tested and confirmed working
- **Corrected command names**: Removed non-existent commands, added actual working commands
- **Updated examples**: All code examples reflect the current implementation

### 🚀 **Enhanced Quick Start**
- **Primary focus on testing**: Highlights `nix develop` + `run-test-vm-with-hwinfo` workflow
- **Step-by-step testing guide**: Clear instructions for verifying functionality
- **Automated testing options**: Both interactive and automated test modes

### 🔧 **Accurate NixOS Module Documentation**
- **Correct module names**: `acpi-hwinfo-host`, `acpi-hwinfo-guest`, `acpi-hwinfo`
- **Accurate options**: All configuration options match actual module definitions
- **Complete examples**: Working flake input and module configuration examples

### 📦 **Comprehensive Command Reference**
- **Development environment commands**: All commands available in `nix develop`
- **Direct package usage**: All `nix run .#` commands with descriptions
- **Testing commands**: Complete testing workflow documentation

### 🏗️ **Updated Architecture & Technical Details**
- **Current project structure**: Reflects actual directory layout
- **Enhanced hardware detection**: Documents the improved NVMe detection with fallbacks
- **Debug mode documentation**: How to enable detailed logging
- **Integration points**: MicroVM, QEMU, NixOS modules

## 🧪 **Verification Process**

All commands and examples in the updated README have been tested:

✅ `nix develop` - Development environment entry  
✅ `acpi-hwinfo` - Hardware status command in devshell  
✅ `run-test-vm-with-hwinfo` - Main testing command  
✅ `run-automated-vm-test` - Automated testing  
✅ `nix run .#hwinfo-status` - Hardware detection status  
✅ `nix run .#acpi-hwinfo-generate` - ACPI generation  
✅ All other documented commands verified working  

## 🎯 **Focus Areas**

### Primary Use Case
The README now prioritizes the main testing workflow:
1. `git clone` + `cd` + `nix develop`
2. `run-test-vm-with-hwinfo` 
3. Verify VM boots with hardware info injection

### Developer Experience
- Clear development workflow
- Comprehensive testing options
- Debug mode documentation
- Requirements and setup information

### Production Usage
- Accurate NixOS module configuration
- Integration examples
- Architecture documentation

## 📋 **Changes Summary**

- **Removed**: Outdated traditional usage section, incorrect commands
- **Added**: Comprehensive testing guide, debug mode docs, accurate module examples
- **Updated**: All command examples, architecture documentation, requirements
- **Verified**: Every single command and example tested and confirmed working

This README now serves as a reliable, accurate guide for both testing the functionality and integrating it into production systems.

@juliuskoskela can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ccf7e3b953da451285a63b05a637c3e2)